### PR TITLE
Fix jemmy build script and uitest run script to get passing build

### DIFF
--- a/scripts/2_setup_jemmy.py
+++ b/scripts/2_setup_jemmy.py
@@ -12,7 +12,7 @@ JMC_ROOT = QA_ROOT + 'jmc/'
 JMC_JEMMY_LIB = JMC_ROOT + '/application/uitests/org.openjdk.jmc.test.jemmy/lib/'
 
 JEMMY_REPO = 'http://hg.openjdk.java.net/code-tools/jemmy/v3/'
-HG_CLONE_JEMMY = ['hg', 'clone', JEMMY_REPO, '../jemmy']
+HG_CLONE_JEMMY = ['hg', 'clone', JEMMY_REPO, JEMMY_ROOT]
 
 MVN_CLEAN_PACKAGE = ['mvn', 'clean', 'package'] # fails at the moment
 MVN_CLEAN_PACKAGE_SKIP_TESTS = ['mvn', 'clean', 'package', '-DskipTests']

--- a/scripts/3_run_ui_tests.py
+++ b/scripts/3_run_ui_tests.py
@@ -8,7 +8,8 @@ HOME = os.path.expanduser('~')
 QA_ROOT = HOME+ '/workspace/jmc-qa/'
 JMC_ROOT = QA_ROOT + 'jmc/'
 JMC_THIRD_PARTY = JMC_ROOT + 'releng/third-party/'
-JMC_UI_TESTS_POM = JMC_ROOT + 'application/uitests/pom.xml'
+JMC_CONSOLE_UITEST_DIR = JMC_ROOT + 'application/uitests/org.openjdk.jmc.console.uitest/'
+MBeansTest_intermittentMBeanTest = JMC_CONSOLE_UITEST_DIR + 'src/test/java/org/openjdk/jmc/console/uitest/MBeansTest.java'
 
 MVN_JETTY_RUN = ['mvn', 'jetty:run']
 MVN_VERIFY_UI_TESTS = ['mvn', 'verify', '-P', 'uitests']
@@ -24,10 +25,9 @@ def run_ui_tests():
   subprocess.call(MVN_VERIFY_UI_TESTS_SKIP_SPOTBUGS)
 
 def remove_failing_tests():
-  # Currently the only failing tests are in the jmc.console.uitest package .. so skip them for now
-  console_console_uitest_module = r'<module>org.openjdk.jmc.console.uitest<\/module>'
-  commented_console_uitest_module = r'<!-- <module>org.openjdk.jmc.console.uitest<\/module> -->'
-  os.system('sed -i \'s/' + console_console_uitest_module + '/' + commented_console_uitest_module + '/\' '+ JMC_UI_TESTS_POM)
+  # The test causing failure is MBeansTest.intermittentMBeanTest() in jmc.console.uitest
+  os.system('sed -i \'125,150 s/^/\/\//\' ' + MBeansTest_intermittentMBeanTest)
+
 
 def main():
   remove_failing_tests()


### PR DESCRIPTION
This PR accomplishes two things:

1. Fixes the path when cloning Jemmy
2. Comments out only the problematic ui test that is causing uitests to fail