### PR TITLE
Better handle maven failures and introduce entry point script

### DIFF
--- a/scripts/1_setup_jmc.py
+++ b/scripts/1_setup_jmc.py
@@ -20,12 +20,11 @@ MVN_P2_SITE = ['mvn', 'p2:site']
 MVN_JETTY_RUN = ['mvn', 'jetty:run']
 
 def clone_repo():
-  if not os.path.isdir(JMC_ROOT):
-    subprocess.call(HG_CLONE_JMC)
+  return subprocess.call(HG_CLONE_JMC)
 
 def p2site():
   os.chdir(JMC_THIRD_PARTY)
-  subprocess.call(MVN_P2_SITE)
+  return subprocess.call(MVN_P2_SITE)
 
 def jetty_run():
   os.chdir(JMC_THIRD_PARTY)
@@ -34,19 +33,23 @@ def jetty_run():
   
 def build_jmc_core():
   os.chdir(JMC_CORE)
-  subprocess.call(MVN_CLEAN_INSTALL)
+  return subprocess.call(MVN_CLEAN_INSTALL)
 
 def build_jmc():
   os.chdir(JMC_ROOT)
-  subprocess.call(MVN_PACKAGE)
+  return subprocess.call(MVN_PACKAGE)
 
 def main():
-  clone_repo()
-  p2site()
+  if clone_repo() != 0:
+    raise Exception('Unable to clone JMC!')
+  if p2site() != 0:
+    raise Exception('Unable to setup p2 repository!')
   proc = jetty_run()
-  build_jmc_core()
+  if build_jmc_core() != 0:
+    raise Exception('Unable to build JMC Core!')
   proc.kill()
-  build_jmc()
+  if build_jmc() != 0:
+    raise Exception('Unable to build JMC!')
 
 if __name__ == '__main__':
   main()

--- a/scripts/2_setup_jemmy.py
+++ b/scripts/2_setup_jemmy.py
@@ -18,12 +18,11 @@ MVN_CLEAN_PACKAGE = ['mvn', 'clean', 'package'] # fails at the moment
 MVN_CLEAN_PACKAGE_SKIP_TESTS = ['mvn', 'clean', 'package', '-DskipTests']
 
 def clone_jemmy():
-  if os.path.isdir(JEMMY_ROOT) is False:
-    subprocess.call(HG_CLONE_JEMMY)
+  return subprocess.call(HG_CLONE_JEMMY)
 
 def build_jemmy():
   os.chdir(JEMMY_ROOT)
-  subprocess.call(MVN_CLEAN_PACKAGE_SKIP_TESTS)
+  return subprocess.call(MVN_CLEAN_PACKAGE_SKIP_TESTS)
 
 def transfer_jars():
   if not os.path.exists(JMC_JEMMY_LIB):
@@ -35,8 +34,10 @@ def transfer_jars():
       shutil.copy(jar, JMC_JEMMY_LIB)
     
 def main():
-  clone_jemmy()
-  build_jemmy()
+  if clone_jemmy() != 0:
+    raise Exception('Unable to clone Jemmy!')
+  if build_jemmy() != 0:
+    raise Exception('Unable to build Jemmy!')
   transfer_jars()
 
 if __name__ == '__main__':

--- a/scripts/3_run_ui_tests.py
+++ b/scripts/3_run_ui_tests.py
@@ -22,7 +22,7 @@ def jetty_run():
 
 def run_ui_tests():
   os.chdir(JMC_ROOT)
-  subprocess.call(MVN_VERIFY_UI_TESTS_SKIP_SPOTBUGS)
+  return subprocess.call(MVN_VERIFY_UI_TESTS_SKIP_SPOTBUGS)
 
 def remove_failing_tests():
   # The test causing failure is MBeansTest.intermittentMBeanTest() in jmc.console.uitest
@@ -32,7 +32,8 @@ def remove_failing_tests():
 def main():
   remove_failing_tests()
   proc = jetty_run()
-  run_ui_tests()
+  if run_ui_tests() != 0:
+    raise Exception('uitests have failed to pass!')
   proc.kill()
 
 if __name__ == '__main__':

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import os, subprocess
+
+HOME = os.path.expanduser('~')
+SCRIPTS_ROOT = HOME + '/workspace/jmc-qa/scripts/'
+
+def setup_jmc():
+  return subprocess.call(['python3', SCRIPTS_ROOT + '1_setup_jmc.py'])
+
+def setup_jemmy():
+  return subprocess.call(['python3', SCRIPTS_ROOT + '2_setup_jemmy.py'])
+
+def run_ui_tests():
+  return subprocess.call(['python3', SCRIPTS_ROOT + '3_run_ui_tests.py'])
+
+def main():
+  if setup_jmc() != 0:
+    raise Exception('Something happened attempting to setup JMC.')
+  if setup_jemmy() != 0:
+    raise Exception('Something happened attempting to setup Jemmy.')
+  if run_ui_tests() != 0:
+    raise Exception('Something happened attempting to verify uitests.')
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
This PR addresses issues https://github.com/aptmac/jmc-qa/issues/7 and https://github.com/aptmac/jmc-qa/issues/9, which encompass exception handling and having a base script.

Currently if maven commands exit with a fail code there is no way to prevent the rest of the script from executing. To amend this, the exit code is returned from the subprocess call, and an exception is thrown if it is not `0`. A message indicating the approximate error is printed to the console as well.

A base script called `run.py` has also been introduced, so that it can be a point of entry for all of the other scripts.