### PR TITLE
Increase the virtual display size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ addons:
                         - xvfb
 install:
         - export DISPLAY=':99.0'
-        - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+        - Xvfb :99 -screen 0 1920x1080x24 > /dev/null 2>&1 &
 script: scripts/run.sh

--- a/scripts/3_run_ui_tests.sh
+++ b/scripts/3_run_ui_tests.sh
@@ -17,11 +17,8 @@ jetty_pid=$!;
 # add a cursor placement for 0, 0 in the RCP application setup
 sed -i '53 i 		display.setCursorLocation(0, 0);' $RCP_APPLICATION_JAVA
 
-# see what happens if we remove the persistence test ..
-sed -i '46d' $UITEST_POM
-
-# .. and the console.uitest because MBeanBrowserTabTest is failing ..
-sed -i '46d' $UITEST_POM
+# temp: ignore running the console.uitest
+sed -i '47d' $UITEST_POM
 
 # remove a conflicting Eclipse shortcut
 sed -i '140d' $RCP_APPLICATION_PLUGIN_XML


### PR DESCRIPTION
Addresses https://github.com/aptmac/jmc-qa/issues/23

The default screen size for Xvfb is 800x600, which appears to have been causing issues with the UI tests. `PersistenceTest` was passing when running locally on my machine, but failing in my Travis and Jenkins setups. The test fails by not being able to interact with a ui element as expected; it cannot find it. Increasing the screen dimensions allows the test to find the expected element, and run the test accordingly.