### PR TITLE
change hardcoded font height value of 11 to be JFace default height in MBeanBrowserTabTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: java
 sudo: true
 cache:
   directories:
-  - $HOME/.m2
+    - $HOME/.m2
 addons:
-        apt:
-                packages:
-                        - xvfb
+  apt:
+    packages:
+        - xvfb
 install:
-        - export DISPLAY=':99.0'
-        - Xvfb :99 -screen 0 1920x1080x24 > /dev/null 2>&1 &
+  - export DISPLAY=':99.0'
+  - Xvfb :99 -screen 0 1920x1080x24 > /dev/null 2>&1 &
 script: scripts/run.sh

--- a/scripts/1_setup_jmc.sh
+++ b/scripts/1_setup_jmc.sh
@@ -18,7 +18,7 @@ hg clone $JMC_REPO $JMC_ROOT || { exit 1; };
 mvn p2:site -f $JMC_THIRD_PARTY/pom.xml || { exit 1; };
 
 # run the jetty server in the background
-mvn jetty:run -f $JMC_THIRD_PARTY/pom.xml &;
+mvn jetty:run -f $JMC_THIRD_PARTY/pom.xml &
 jetty_pid=$!;
 
 # build jmc-core

--- a/scripts/2_setup_jemmy.sh
+++ b/scripts/2_setup_jemmy.sh
@@ -22,7 +22,7 @@ fi
 hg clone $JEMMY_REPO $JEMMY_ROOT  || { exit 1; };
 
 # build jemmy
-mvn clean package -DskipTests --quiet -f $JEMMY_ROOT || { exit 1; };
+mvn clean package -DskipTests --quiet -f $JEMMY_ROOT/pom.xml || { exit 1; };
 
 # create the jemmy lib folder
 mkdir $JMC_JEMMY_LIB;

--- a/scripts/3_run_ui_tests.sh
+++ b/scripts/3_run_ui_tests.sh
@@ -4,24 +4,23 @@ JMC_QA=~/workspace/jmc-qa
 JMC_ROOT=$JMC_QA/jmc
 JMC_CORE=$JMC_ROOT/core
 JMC_THIRD_PARTY=$JMC_ROOT/releng/third-party
-JMC_CONSOLE_UITEST_DIR=$JMC_ROOT/application/uitests/org.openjdk.jmc.console.uitest
+MBeanBrowserTabTest=$JMC_ROOT/application/uitests/org.openjdk.jmc.console.uitest/src/test/java/org/openjdk/jmc/console/uitest/MBeanBrowserTabTest.java
 RCP_APPLICATION_FOLDER=$JMC_ROOT/application/org.openjdk.jmc.rcp.application
 RCP_APPLICATION_JAVA=$RCP_APPLICATION_FOLDER/src/main/java/org/openjdk/jmc/rcp/application/Application.java
-RCP_APPLICATION_PLUGIN_XML=$RCP_APPLICATION_FOLDER/plugin.xml
-UITEST_POM=$JMC_ROOT/application/uitests/pom.xml
 
 # run the jetty server in the background
 mvn jetty:run -f $JMC_THIRD_PARTY/pom.xml &
 jetty_pid=$!;
 
-# add a cursor placement for 0, 0 in the RCP application setup
+# Addresses https://github.com/aptmac/jmc-qa/issues/16
+# The RCP application will not display if not given mouse focus.
+# Add a cursor placement for 0, 0 in the RCP application setup.
 sed -i '53 i 		display.setCursorLocation(0, 0);' $RCP_APPLICATION_JAVA
 
-# temp: ignore running the console.uitest
-sed -i '47d' $UITEST_POM
-
-# remove a conflicting Eclipse shortcut
-sed -i '140d' $RCP_APPLICATION_PLUGIN_XML
+# Addresses https://github.com/aptmac/jmc-qa/issues/22
+# MBeanBrowserTabTest.testValueFontSize() asserts that a font can be resized to the system default height.
+# However, the test uses a hardcoded value of 11 to test against, and the default for Travis & Jenkins is 10.
+sed -i 's/DEFAULT_FONT_HEIGHT = 11/DEFAULT_FONT_HEIGHT = JFaceResources.getDefaultFont().getFontData()[0].getHeight()/' $MBeanBrowserTabTest
 
 # run ui tests
 mvn verify -P uitests -Dspotbugs.skip=true -f $JMC_ROOT/pom.xml || { kill $jetty_pid; exit 1; };

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Clone the JMC repo, build jmc-core and jmc
 bash ./scripts/1_setup_jmc.sh
+
+# Clone the Jemmy repo, build it, and move the resulting jars into jmc
 bash ./scripts/2_setup_jemmy.sh
+
+# Run the ui tests
 bash ./scripts/3_run_ui_tests.sh


### PR DESCRIPTION
This PR addresses issue https://github.com/aptmac/jmc-qa/issues/22, in which the `MBeanBrowserTabTest` [0] is encountering test failures. This PR introduces a change to the unit test that allows the uitests to pass and continue. Travis logs available at [1].

The problematic test was `testValueFontSize` [2], in which a larger font size (16) was converted to a lower size (11) to simulate the ui converting all font to the system default for consistency. However, the value 11 was hardcoded [3], and is not the default value on all systems. For example, the Travis system (as well as my own machine) has font size 10 as the default value, so even though the unit test correctly resizes the larger font to a smaller font, the font is too large and there is a mismatch. This PR changes the hardcoded value of 11 to be `JFaceResources.getDefaultFont().getFontData()[0].getHeight()` and use the actual default value.

Additionally, I have added a couple comments and cleaned up other text in the scripts.

[0] https://github.com/aptmac/jmc-qa/issues/22
[1] https://api.travis-ci.org/v3/job/475039412/log.txt
[2] http://hg.openjdk.java.net/jmc/jmc/rev/c4b6a87219c3#l2.89
[3] http://hg.openjdk.java.net/jmc/jmc/rev/c4b6a87219c3#l2.35