### PR TITLE
move path variables to config.sh and fix relative paths

### DIFF
--- a/scripts/1_setup_jmc.sh
+++ b/scripts/1_setup_jmc.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
-
-JMC_QA=~/workspace/jmc-qa
-JMC_ROOT=$JMC_QA/jmc
-JMC_CORE=$JMC_ROOT/core
-JMC_THIRD_PARTY=$JMC_ROOT/releng/third-party
-JMC_REPO=http://hg.openjdk.java.net/jmc/jmc/
+source $(dirname "$0")/config.sh
 
 # if a jmc folder already exists, remove it prior to cloning
 if [ -d $JMC_ROOT ]; then

--- a/scripts/2_setup_jemmy.sh
+++ b/scripts/2_setup_jemmy.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
-
-JMC_QA=~/workspace/jmc-qa
-JEMMY_ROOT=$JMC_QA/jemmy
-JEMMY_REPO=http://hg.openjdk.java.net/code-tools/jemmy/v3/
-JMC_ROOT=$JMC_QA/jmc
-JMC_JEMMY_LIB=$JMC_ROOT/application/uitests/org.openjdk.jmc.test.jemmy/lib/
-MCJEMMYTESTBASE=$JMC_ROOT/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/MCJemmyTestBase.java
-
-# jar output directories
-JEMMY_AWTINPUT=$JEMMY_ROOT/core/JemmyAWTInput/target
-JEMMY_BROWSER=$JEMMY_ROOT/core/JemmyBrowser/target
-JEMMY_CORE=$JEMMY_ROOT/core/JemmyCore/target
-JEMMY_SWT=$JEMMY_ROOT/SWT/JemmySWT/target
+source $(dirname "$0")/config.sh
 
 # if a jemmy folder already exists, remove it prior to cloning
 if [ -d $JEMMY_ROOT ]; then
@@ -43,6 +31,3 @@ done
 for jar in `ls $JEMMY_SWT | grep .jar`; do
   mv $JEMMY_SWT/$jar $JMC_JEMMY_LIB;
 done
-
-# increase the timeout for focusing JMC window
-sed -i '86 s/sleep(10000)/sleep(50000)/' $MCJEMMYTESTBASE

--- a/scripts/3_run_ui_tests.sh
+++ b/scripts/3_run_ui_tests.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-JMC_QA=~/workspace/jmc-qa
-JMC_ROOT=$JMC_QA/jmc
-JMC_CORE=$JMC_ROOT/core
-JMC_THIRD_PARTY=$JMC_ROOT/releng/third-party
-MBeanBrowserTabTest=$JMC_ROOT/application/uitests/org.openjdk.jmc.console.uitest/src/test/java/org/openjdk/jmc/console/uitest/MBeanBrowserTabTest.java
-RCP_APPLICATION_FOLDER=$JMC_ROOT/application/org.openjdk.jmc.rcp.application
-RCP_APPLICATION_JAVA=$RCP_APPLICATION_FOLDER/src/main/java/org/openjdk/jmc/rcp/application/Application.java
+source $(dirname "$0")/config.sh
 
 # run the jetty server in the background
 mvn jetty:run -f $JMC_THIRD_PARTY/pom.xml &
@@ -20,7 +13,7 @@ sed -i '53 i 		display.setCursorLocation(0, 0);' $RCP_APPLICATION_JAVA
 # Addresses https://github.com/aptmac/jmc-qa/issues/22
 # MBeanBrowserTabTest.testValueFontSize() asserts that a font can be resized to the system default height.
 # However, the test uses a hardcoded value of 11 to test against, and the default for Travis & Jenkins is 10.
-sed -i 's/DEFAULT_FONT_HEIGHT = 11/DEFAULT_FONT_HEIGHT = JFaceResources.getDefaultFont().getFontData()[0].getHeight()/' $MBeanBrowserTabTest
+sed -i 's/DEFAULT_FONT_HEIGHT = 11/DEFAULT_FONT_HEIGHT = JFaceResources.getDefaultFont().getFontData()[0].getHeight()/' $MBEAN_BROWSER_TAB_TEST
 
 # run ui tests
 mvn verify -P uitests -Dspotbugs.skip=true -f $JMC_ROOT/pom.xml || { kill $jetty_pid; exit 1; };

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -1,0 +1,23 @@
+# repos
+JMC_REPO=http://hg.openjdk.java.net/jmc/jmc/
+JEMMY_REPO=http://hg.openjdk.java.net/code-tools/jemmy/v3/
+
+# jmc
+JMC_QA=$(dirname "$0")/../
+JMC_ROOT=$JMC_QA/jmc
+JMC_CORE=$JMC_ROOT/core
+JMC_THIRD_PARTY=$JMC_ROOT/releng/third-party
+
+# jemmy
+JEMMY_ROOT=$JMC_QA/jemmy
+JMC_JEMMY_LIB=$JMC_ROOT/application/uitests/org.openjdk.jmc.test.jemmy/lib/
+
+# jemmy jar output directories
+JEMMY_AWTINPUT=$JEMMY_ROOT/core/JemmyAWTInput/target
+JEMMY_BROWSER=$JEMMY_ROOT/core/JemmyBrowser/target
+JEMMY_CORE=$JEMMY_ROOT/core/JemmyCore/target
+JEMMY_SWT=$JEMMY_ROOT/SWT/JemmySWT/target
+
+# ui test 
+MBEAN_BROWSER_TAB_TEST=$JMC_ROOT/application/uitests/org.openjdk.jmc.console.uitest/src/test/java/org/openjdk/jmc/console/uitest/MBeanBrowserTabTest.java
+RCP_APPLICATION_JAVA=$JMC_ROOT/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/application/Application.java

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Clone the JMC repo, build jmc-core and jmc
-bash ./scripts/1_setup_jmc.sh
+bash $(dirname "$0")/1_setup_jmc.sh
 
 # Clone the Jemmy repo, build it, and move the resulting jars into jmc
-bash ./scripts/2_setup_jemmy.sh
+bash $(dirname "$0")/2_setup_jemmy.sh
 
 # Run the ui tests
-bash ./scripts/3_run_ui_tests.sh
+bash $(dirname "$0")/3_run_ui_tests.sh


### PR DESCRIPTION
This PR addresses https://github.com/aptmac/jmc-qa/issues/11 [0], which involves cleaning up the relative paths used in the scripts. Additionally, the common path variables have been extracted from the individual scripts and moved to `config.sh` for easy editing/storing/using.

[0] https://github.com/aptmac/jmc-qa/issues/11