### PR TITLE
remove the skip spotbugs arg for ui tests

### DIFF
--- a/scripts/3_run_ui_tests.sh
+++ b/scripts/3_run_ui_tests.sh
@@ -11,7 +11,8 @@ jetty_pid=$!;
 sed -i '53 i 		display.setCursorLocation(0, 0);' $RCP_APPLICATION_JAVA
 
 # run ui tests
-mvn verify -P uitests -Dspotbugs.skip=true -f $JMC_ROOT/pom.xml || { kill $jetty_pid; exit 1; };
+cd $JMC_ROOT
+mvn verify -P uitests || { kill $jetty_pid; exit 1; };
 
 # kill the jetty process
 kill $jetty_pid;


### PR DESCRIPTION
I had left out spotbugs (as written in the readme) without giving it too much thought; Spotbugs should be enabled to flag potential errors. Specifically this has come to light because the fix for JMC-6128 [0] to integrate openjfx flags errors with the `org.openjdk.jmc.joverflow.ui` and will cease the build.

An example of the failures can be found in the Travis logs [1]

[0] https://bugs.openjdk.java.net/browse/JMC-6128
[1] https://api.travis-ci.org/v3/job/482559097/log.txt