### PR TITLE
make sure to use JDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+dist: trusty
 language: java
+jdk: oraclejdk8
 sudo: true
 cache:
   directories:


### PR DESCRIPTION
A recent update to use Ubuntu Xenial has caused builds to fail, because it uses OpenJDK11 instead of Oracle JDK8 by default.