### PR TITLE
Update README to include Travis build badges for macOS and Windows branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# JMC QA [![Build Status](https://travis-ci.org/aptmac/jmc-qa.svg?branch=master)](https://travis-ci.org/aptmac/jmc-qa)
+# JMC QA
+<b>Linux</b> (Ubuntu Trusty) [![Build Status](https://travis-ci.org/aptmac/jmc-qa.svg?branch=master)](https://travis-ci.org/aptmac/jmc-qa)<br>
+<b>macOS</b> (macOS 10.13) [![Build Status](https://travis-ci.org/aptmac/jmc-qa.svg?branch=osx)](https://travis-ci.org/aptmac/jmc-qa)<br>
+<b>Windows</b> (Windows Server 1803) [![Build Status](https://travis-ci.org/aptmac/jmc-qa.svg?branch=windows)](https://travis-ci.org/aptmac/jmc-qa)
 
-Collection of scripts to download and setup Java Mission Control (JMC), setup the Jemmy ui test library, and run tests (unit & uitests).
+Collection of scripts to download and setup Java Mission Control (JMC), setup the Jemmy ui test library, and run tests (unit & uitests*).
 
-Note: these instructions and scripts currently apply to the Fedora OS and may require adjustments to run properly otherwise.
+\* uitests currently only run properly in Travis for Linux builds
 
 ## Requirements
 

--- a/scripts/1_setup_jmc.sh
+++ b/scripts/1_setup_jmc.sh
@@ -19,8 +19,5 @@ jetty_pid=$!;
 # build jmc-core
 mvn clean install --quiet -f $JMC_CORE/pom.xml || { exit 1; };
 
-# build jmc
-mvn package --quiet -f $JMC_ROOT/pom.xml || { exit 1; };
-
 # kill the jetty process
 kill $jetty_pid;

--- a/scripts/3_run_ui_tests.sh
+++ b/scripts/3_run_ui_tests.sh
@@ -12,7 +12,7 @@ sed -i '53 i 		display.setCursorLocation(0, 0);' $RCP_APPLICATION_JAVA
 
 # run ui tests
 cd $JMC_ROOT
-mvn verify -P uitests || { kill $jetty_pid; exit 1; };
+mvn verify --quiet -P uitests -Dspotbugs.skip=true || { kill $jetty_pid; exit 1; };
 
 # kill the jetty process
 kill $jetty_pid;


### PR DESCRIPTION
This PR introduces new Travis CI build badges to the README for quick viewing. The two new badges correspond to daily cron builds of the macOS and Windows branches which build jmc-core and jmc (but not uitests at the moment).